### PR TITLE
Fix emerge time for packages whose names contains special chars

### DIFF
--- a/showem
+++ b/showem
@@ -191,8 +191,8 @@ get_extra_info() {
     # TOTAL is the total number of packages in that emerge sequence.
 
     # Inspired by https://github.com/gentoo-perl/genlop/blob/master/genlop#L625
-    grep -E -e '^[0-9]+:  >>> emerge \([0-9]+ of [0-9]+\) '"$PKGNAME"' to' "$MAIN_LOG_DIR/$EMERGE_LOG" | \
-        tail -n1 | sed -re 's@^([0-9]+):  >>> emerge \(([0-9]+) of ([0-9]+)\) ('"$PKGNAME"') to.*@\1 \2 \3@'
+    perl -ne 's@^([0-9]+):  >>> emerge \(([0-9]+) of ([0-9]+)\) (\Q'"$PKGNAME"'\E) to.*@\1 \2 \3@ and print' "$MAIN_LOG_DIR/$EMERGE_LOG" | \
+        tail -n1
 }
 monitor_current_builds() {
     # This function reports any changes from the last scan


### PR DESCRIPTION
After fix:
![image](https://user-images.githubusercontent.com/299873/107454186-8df69000-6b1a-11eb-929c-ca04d5806abc.png)

Before fix:
![image](https://user-images.githubusercontent.com/299873/107454208-94850780-6b1a-11eb-904c-268fe459709f.png)
